### PR TITLE
/Syntax/index bug fix & Breadcrumb Complete

### DIFF
--- a/src/components/Syntax/index.js
+++ b/src/components/Syntax/index.js
@@ -108,7 +108,7 @@ function SyntaxSelectComponent({ example, title, level, summary }) {
         <SyntaxLevel>{stars}</SyntaxLevel>
       </SyntaxTitleBox>
       <SyntaxSummary>{summary}</SyntaxSummary>
-      <SyntaxStartButton onClick={""}>시작하기!</SyntaxStartButton>
+      <SyntaxStartButton onClick={() => {}}>시작하기!</SyntaxStartButton>
     </SyntaxSelectContainer>
   );
 }

--- a/src/components/common/Breadcrumb/index.js
+++ b/src/components/common/Breadcrumb/index.js
@@ -6,44 +6,74 @@ import {
   Arrow,
 } from "components/common/Breadcrumb/styles";
 import { Link, useLocation } from "react-router-dom";
+import { SYNTAXES } from "constants/syntaxes";
 
 function Breadcrumbs() {
   const location = useLocation();
+  // url array, /python/1이면 ["python", "1"] 로 저장
+  const locationArray = location.pathname.split("/").filter((entry) => entry !== "");
+  const locArrLen = locationArray.length;
+  // codeId가 있는 url이라면 codeId 반환, 없다면 undefined
+  const codeId = locationArray[locArrLen - 1];
+  // language있으면 language 반환, 없으면 undefined
+  const language = locationArray[0];
+  const firstUpLanguage = language.toLowerCase().replace(/\b[a-z]/g, function (letter) {
+    return letter.toUpperCase();
+  });
+  // url이 특정 path로 시작하는지 확인하여 보여주고 안 보여주고 나눔(있는 이유는 languageselect 때도 breadcrumb이 나타나서)
+  function UrlStartsWith(path) {
+    return location.pathname.startsWith(path);
+  }
+  // style 관련 state 나타내는 varibles
+  const SHOWN = "shown";
+  const NOT_SHOWN = "notShown";
+  const BREADCRUMB_ACTIVE = "breadcrumb-active";
+  const BREADCRUMB_NOT_ACTIVE = "breadcrumb-not-active";
+  const BREADCRUMB_ARROW = "breadcrumb-Arrow";
+
   return (
     <StyledBreadcrumb>
-      <BreadcrumbShown status={location.pathname.startsWith("/") ? "shown" : "notShown"}>
-        <Link to="/">
-          <BreadcrumbColor
-            status={
-              !location.pathname.startsWith("/python")
-                ? "breadcrumb-active"
-                : "breadcrumb-not-active"
-            }
-          >
+      <BreadcrumbShown
+        status={locArrLen >= 0 ? (UrlStartsWith("/") ? SHOWN : NOT_SHOWN) : NOT_SHOWN}
+      >
+        <Link to="/languageselect">
+          <BreadcrumbColor status={locArrLen === 0 ? BREADCRUMB_ACTIVE : BREADCRUMB_NOT_ACTIVE}>
             TTDTT
           </BreadcrumbColor>
         </Link>
       </BreadcrumbShown>
-      <BreadcrumbShown status={location.pathname.startsWith("/python") ? "shown" : "notShown"}>
-        <Arrow className="breadcrumb-Arrow">&gt;</Arrow>
-        <Link to="/python">
-          <BreadcrumbColor
-            status={
-              !location.pathname.startsWith("/python/typePage")
-                ? "breadcrumb-active"
-                : "breadcrumb-not-active"
-            }
-          >
-            python
+      <BreadcrumbShown
+        status={
+          locationArray.length >= 1
+            ? !UrlStartsWith("/languageselect")
+              ? SHOWN
+              : NOT_SHOWN
+            : NOT_SHOWN
+        }
+      >
+        <Arrow className={BREADCRUMB_ARROW}>&gt;</Arrow>
+        <Link to={`/${language}`}>
+          <BreadcrumbColor status={locArrLen === 1 ? BREADCRUMB_ACTIVE : BREADCRUMB_NOT_ACTIVE}>
+            {firstUpLanguage}
           </BreadcrumbColor>
         </Link>
       </BreadcrumbShown>
       <BreadcrumbShown
-        status={location.pathname.startsWith("/python/typePage") ? "shown" : "notShown"}
+        status={
+          locationArray >= 2
+            ? UrlStartsWith(`/${language}/${codeId}`)
+              ? SHOWN
+              : NOT_SHOWN
+            : NOT_SHOWN
+        }
       >
-        <Arrow className="breadcrumb-Arrow">&gt;</Arrow>
+        <Arrow className={BREADCRUMB_ARROW}>&gt;</Arrow>
         <Link>
-          <BreadcrumbColor status="breadcrumb-active">while.html</BreadcrumbColor>
+          <BreadcrumbColor status={BREADCRUMB_ACTIVE}>
+            {isNaN(parseInt(codeId))
+              ? "error"
+              : SYNTAXES[firstUpLanguage][parseInt(codeId) - 1]["title"]}
+          </BreadcrumbColor>
         </Link>
       </BreadcrumbShown>
     </StyledBreadcrumb>

--- a/src/components/common/Breadcrumb/styles.js
+++ b/src/components/common/Breadcrumb/styles.js
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled/macro";
+import { hexToRgba } from "utils/color";
 
 export const StyledBreadcrumb = styled.nav`
   display: flex;
@@ -27,7 +28,7 @@ export const BreadcrumbColor = styled.div`
       : props.theme.color.primary500};
   border-radius: 6px;
   &:hover {
-    background-color: rgba(71, 96, 250, 0.3);
+    background-color: ${(props) => hexToRgba(props.theme.color.primary500, 0.3)};
   }
 `;
 


### PR DESCRIPTION
Related to #{이슈 번호 기입}

## 체크 리스트

- [ ] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [ ] Target Branch를 올바르게 설정했나요?
- [ ] Label을 알맞게 설정했나요?

## 작업 내역

- Syntax/index에 onClick=(“”) 을 onClick={ () => {} } 으로 수정
- Breadcrumb shown, notShown, breadcrumb-... 변수처리
- StartsWith로 하던 것을 url을 "/" 기준으로 array로 할당하여 array 길이 기준으로 나눔
- array 길이로만 나누었을 때 languageselect도 breadcrumb이 생기는 것을 방지하기위해 추가로 StartsWith 조건 부여
- 해당 language페이지에서 language 표시
- typepage 1, 2, 3, 4 .. -> SYNTAXES로 처리
- styles hextoRgb로 적용 

## 비고

- 
