### PR TITLE
(임시로) 서비스명을 ttdtt 에서 TADAK 으로 통일하는 작업

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.16.0
 
-WORKDIR /ttdttfe
+WORKDIR /tadakfe
 
 COPY ./ ./
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "beta-idea-test",
+  "name": "tadak-frontend",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "beta-idea-test",
+      "name": "tadak-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "beta-idea-test",
+  "name": "tadak-frontend",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/components/common/Breadcrumb/index.js
+++ b/src/components/common/Breadcrumb/index.js
@@ -40,7 +40,7 @@ function Breadcrumbs(props) {
           >
             <Link to="/languageselect">
               <BreadcrumbColor status={locArrLen === 0 ? BREADCRUMB_ACTIVE : BREADCRUMB_NOT_ACTIVE}>
-                TTDTT
+                TADAK
               </BreadcrumbColor>
             </Link>
           </BreadcrumbShown>

--- a/src/components/common/NavBar/index.js
+++ b/src/components/common/NavBar/index.js
@@ -27,7 +27,7 @@ function NavBar(props) {
   const { loggedOut, user } = useUser();
 
   const handleLogout = useCallback(() => {
-    deleteCookie("ttdtt_web_token", "*", "localhost:3000");
+    deleteCookie("tadak_web_token", "*", "localhost:3000");
     mutate("/users/me");
   }, []);
 


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- Dockerfile 의 `WORKDIR` 을 수정합니다. 
- package.json 및 package-lock.json 의 name 을 수정합니다. 
- 쿠키 key 값을 `ttdtt_web_token` 에서 `tadak_web_token` 으로 수정합니다. 
- `Breadcrumb` 컴포넌트의 root 에 표시되는 명칭을 TTDTT 에서 TADAK 으로 변경합니다. 

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
